### PR TITLE
stdx: Move runtime extension into sperated package

### DIFF
--- a/stdx/envx/readme.go
+++ b/stdx/envx/readme.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 T-Force I/O
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package envx provides common used functions to obtain information of current
+system the application is running.
+Added in v0.2.0
+*/
+package envx

--- a/stdx/envx/runtime.go
+++ b/stdx/envx/runtime.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package stdx
+package envx
 
 import (
 	"runtime"

--- a/stdx/opx/generic_test.go
+++ b/stdx/opx/generic_test.go
@@ -30,14 +30,11 @@ func TestAreEqualSlices(t *testing.T) {
 		{"all nils", nil, nil, true},
 		// one nils
 		{"one nil", []int{}, nil, false},
-		{"one nil", nil, []int{}, false},
 		// different length
 		{"different length", []int{1}, []int{1, 2}, false},
 		{"different length", []int{1}, []int{1, 2, 3}, false},
-		{"different length", []int{1, 2}, []int{1}, false},
 		{"different length", []int{1, 2}, []int{1, 2, 3}, false},
 		{"different length", []int{1, 2}, []int{1, 2, 3, 4}, false},
-		{"different length", []int{1, 2, 3, 4}, []int{1, 2, 3}, false},
 		// deep compare
 		{"deep compare", []int{}, []int{}, true},
 		{"deep compare", []int{1}, []int{1}, true},
@@ -48,7 +45,11 @@ func TestAreEqualSlices(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := AreEqualSlices(tt.x, tt.y)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.y)
+			}
+			result = AreEqualSlices(tt.y, tt.x)
+			if result != tt.expected {
+				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.y, tt.x)
 			}
 		})
 	}
@@ -92,7 +93,7 @@ func TestCoalesce(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := Coalesce(tt.items...)
 			if result.Cmp(tt.expected) != 0 {
-				t.FailNow()
+				t.Errorf("expected %v actual %v intermediate %v", tt.expected, result, tt.items)
 			}
 		})
 	}
@@ -114,7 +115,7 @@ func TestContains(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := Contains(tt.items, tt.value)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual %v intermediate %v %v", tt.expected, result, tt.items, tt.value)
 			}
 		})
 	}
@@ -140,7 +141,7 @@ func TestIsEmptySlice(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := IsEmptySlice(tt.slice)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual %v intermediate %v", tt.expected, result, tt.slice)
 			}
 		})
 	}
@@ -163,7 +164,7 @@ func TestIsEmptyString(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := IsEmptyString(tt.str)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual %v intermediate %v", tt.expected, result, tt.str)
 			}
 		})
 	}
@@ -203,7 +204,7 @@ func TestIsEmptyOrWhitespaceString(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := IsEmptyOrWhitespaceString(tt.str)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual %v intermediate %v", tt.expected, result, tt.str)
 			}
 		})
 	}
@@ -224,7 +225,7 @@ func TestTernary(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := Ternary(tt.cond, tt.x, tt.y)
 			if result != tt.expected {
-				t.FailNow()
+				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.y)
 			}
 		})
 	}

--- a/strfmt/filesys.go
+++ b/strfmt/filesys.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tforce-io/tf-golib/stdx"
+	"github.com/tforce-io/tf-golib/stdx/envx"
 	"github.com/tforce-io/tf-golib/stdx/opx"
 )
 
@@ -182,7 +182,7 @@ func AreEqualPaths(x, y *Path) bool {
 // - Clean the path.
 // Added in v0.2.0
 func NormalizePath(path string) string {
-	nPath := opx.Ternary(stdx.IsWindows(),
+	nPath := opx.Ternary(envx.IsWindows(),
 		strings.ReplaceAll(path, "/", "\\"),
 		strings.ReplaceAll(path, "\\", "/"),
 	)

--- a/strfmt/filesys_test.go
+++ b/strfmt/filesys_test.go
@@ -17,7 +17,7 @@ package strfmt
 import (
 	"testing"
 
-	"github.com/tforce-io/tf-golib/stdx"
+	"github.com/tforce-io/tf-golib/stdx/envx"
 	"github.com/tforce-io/tf-golib/stdx/opx"
 )
 
@@ -49,7 +49,7 @@ func TestNewFileNameFromStr(t *testing.T) {
 		expected *FileName
 	}
 
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"empty", "", &FileName{}},
 			{"root", "/", &FileName{}},
@@ -160,7 +160,7 @@ func TestNewPath(t *testing.T) {
 		file     *FileName
 		expected *Path
 	}
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"empty", []string{}, NewFileNameFromStr(""), &Path{}},
 			{"file_only", []string{}, NewFileNameFromStr("main"), &Path{Name: &FileName{Name: "main"}}},
@@ -193,7 +193,7 @@ func TestNewPathFromStr(t *testing.T) {
 		parents []string
 		name    string
 	}
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"file_only", `main`, []string{}, "main"},
 			{"file_only", `main.go`, []string{}, "main.go"},
@@ -239,7 +239,7 @@ func TestPath_IsAbsolute(t *testing.T) {
 		file     *FileName
 		expected bool
 	}
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"empty", []string{}, NewFileNameFromStr(""), false},
 			{"file_only", []string{}, NewFileNameFromStr("main"), false},
@@ -273,7 +273,7 @@ func TestPath_FullPath(t *testing.T) {
 		file     *FileName
 		expected string
 	}
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"empty", []string{}, NewFileNameFromStr(""), ""},
 			{"file_only", []string{}, NewFileNameFromStr("main"), "main"},
@@ -307,7 +307,7 @@ func TestPath_ParentPath(t *testing.T) {
 		file     *FileName
 		expected string
 	}
-	tests := opx.Ternary(stdx.IsWindows(),
+	tests := opx.Ternary(envx.IsWindows(),
 		[]Test{
 			{"empty", []string{}, NewFileNameFromStr(""), ""},
 			{"file_only", []string{}, NewFileNameFromStr("main"), ""},

--- a/strfmt/filesys_test.go
+++ b/strfmt/filesys_test.go
@@ -143,7 +143,7 @@ func TestAreEqualFileNames(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := AreEqualFileNames(tt.x, tt.y)
 			if result != tt.expected {
-				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.x)
+				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.y)
 			}
 			result = AreEqualFileNames(tt.y, tt.x)
 			if result != tt.expected {
@@ -360,7 +360,7 @@ func TestAreEqualPaths(t *testing.T) {
 		t.Run(tt.group, func(t *testing.T) {
 			result := AreEqualPaths(tt.x, tt.y)
 			if result != tt.expected {
-				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.x)
+				t.Errorf("expected %v actual left %v actual right %v ", tt.expected, tt.x, tt.y)
 			}
 			result = AreEqualPaths(tt.y, tt.x)
 			if result != tt.expected {


### PR DESCRIPTION
According to design, `stdx` package shouldn't have references to sub-package `opx` to prevent later circular references.

Besides, putting `envx` side by side with `opx` will make the code cleaner.